### PR TITLE
Remove metaclass usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: python
 python:
-  - "3.4"
-  - "3.5"
-  - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.9"
+  - "3.10"
 install: pip install tox-travis
 script: tox

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,5 @@ setup(
     license="BSD",
     packages=find_packages(),
     install_requires=("Django>=2",),
+    python_requires='>=3.6',
 )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -24,3 +24,6 @@ SILENCED_SYSTEM_CHECKS = [
     '1_7.W001',
 ]
 ROOT_URLCONF = 'tests.urls'
+
+# Silence warning on Django 4. We don't really care what type it is.
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py36,py37}-django{111,20,21,22}
+envlist = {py37,py38,py39,py310}-django{22,32,40}
 
 [testenv]
 commands =
@@ -8,7 +8,6 @@ commands =
 deps =
     six
     coverage
-    django111: django==1.11
-    django20: django==2.0
-    django21: django==2.1
     django22: django==2.2
+    django32: django==3.2
+    django40: django==4.0


### PR DESCRIPTION
Using `__init_subclass__` rather than a metaclass to register `Item` classes with their enum allows users more flexibility in how they define their item classes, in particular this opens up support for mixing in `typing.Generic` and other types which have their own metaclasses.

This builds on #20 as it only supports Python >= 3.6; the first two commits here are part of that PR.

If we're happy with this approach I'll do some more complete testing of this in a large codebase to validate it works as I hope. Currently I'm just relying on the automated tests in this repo.