### PR TITLE
Exclude the tests directory from the distributed wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author="Chris Lamb",
     author_email="chris@chris-lamb.co.uk",
     license="BSD",
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests*']),
     install_requires=("Django>=2",),
     python_requires='>=3.6',
 )


### PR DESCRIPTION
Previously the tests files were being installed into users' site-packages.

The tests files are still included in the source distribution.

Fixes https://github.com/lamby/django-enumfield-ng/issues/25